### PR TITLE
Flex latest spec pickdrop underscore

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -110,10 +110,10 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, name = "end_service_area_id", mapping = EntityFieldMappingFactory.class, order = -2)
   private Area endServiceArea;
 
-  @CsvField(optional = true, defaultValue = "-999")
+  @CsvField(optional = true, defaultValue = "-999.0")
   private double startServiceAreaRadius;
 
-  @CsvField(optional = true, defaultValue = "-999")
+  @CsvField(optional = true, defaultValue = "-999.0")
   private double endServiceAreaRadius;
 
   @CsvField(ignore = true)
@@ -150,10 +150,10 @@ public final class StopTime extends IdentityBean<Integer> implements
   private double meanDurationOffset = MISSING_VALUE;
     
   @CsvField(optional = true, name = "safe_duration_factor", defaultValue = "-999.0")
-  private double safeDurationFactor= MISSING_VALUE;
+  private double safeDurationFactor = MISSING_VALUE;
 
-  @CsvField(optional = true, name = "safe_duration_offset", defaultValue = "-999")
-  private double safeDurationOffset;
+  @CsvField(optional = true, name = "safe_duration_offset", defaultValue = "-999.0")
+  private double safeDurationOffset = MISSING_VALUE;
 
   @CsvField(optional = true, name = "free_running_flag")
   private String freeRunningFlag;
@@ -387,17 +387,17 @@ public final class StopTime extends IdentityBean<Integer> implements
     return endPickupDropOffWindowWithUnderscore;
   }
 
-//  public void setEndPickupDropOffWindowWithUnderscore(int endPickupDropOffWindowWithUnderscore) {
-//    this.endPickupDropOffWindowWithUnderscore = endPickupDropOffWindowWithUnderscore;
-//  }
+  public void setEndPickupDropOffWindowWithUnderscore(int endPickupDropOffWindowWithUnderscore) {
+    this.endPickupDropOffWindowWithUnderscore = endPickupDropOffWindowWithUnderscore;
+  }
 
   public int getStartPickupDropOffWindowWithUnderscore() {
     return startPickupDropOffWindowWithUnderscore;
   }
 
-//  public void setStartPickupDropOffWindowWithUnderscore(int startPickupDropOffWindowWithUnderscore) {
-//    this.startPickupDropOffWindowWithUnderscore = startPickupDropOffWindowWithUnderscore;
-//  }
+  public void setStartPickupDropOffWindowWithUnderscore(int startPickupDropOffWindowWithUnderscore) {
+    this.startPickupDropOffWindowWithUnderscore = startPickupDropOffWindowWithUnderscore;
+  }
 
   @Override
   public boolean isTimepointSet() {

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -44,7 +44,7 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int arrivalTime = MISSING_VALUE;
 
-  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
+  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
   private int departureTime = MISSING_VALUE;
 
   /**
@@ -52,24 +52,30 @@ public final class StopTime extends IdentityBean<Integer> implements
    * GTFS-Flex v2.1 renamed this field. Use {@link #startPickupDropOffWindow} instead.
    */
   @Deprecated
-  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
+  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
   private int minArrivalTime = MISSING_VALUE;
 
-  @CsvField(optional = true, name = "start_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  @CsvField(optional = true, name = "start_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
   private int startPickupDropOffWindow = MISSING_VALUE;
+
+  @CsvField(optional = true, name = "start_pickup_drop_off_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
+  private int startPickupDropOffWindowWithUnderscore = MISSING_VALUE;
 
   /**
    * @deprecated
    * GTFS-Flex v2.1 renamed this field. Use {@link #endPickupDropOffWindow} instead.
    */
   @Deprecated
-  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
-  private int maxDepartureTime = MISSING_VALUE;
+  @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
+  private int maxDepartureTime;
 
-  @CsvField(optional = true, name = "end_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  @CsvField(optional = true, name = "end_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
   private int endPickupDropOffWindow = MISSING_VALUE;
 
-  @CsvField(optional = true)
+  @CsvField(optional = true, name = "end_pickup_drop_off_window", mapping = StopTimeFieldMappingFactory.class, defaultValue = "-999")
+  private int endPickupDropOffWindowWithUnderscore = MISSING_VALUE;
+
+  @CsvField(optional = true, defaultValue = "-999")
   private int timepoint = MISSING_VALUE;
 
   private int stopSequence;
@@ -89,13 +95,13 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, defaultValue = "0")
   private int dropOffType;
 
-  @CsvField(optional = true)
-  private double shapeDistTraveled = MISSING_VALUE;
+  @CsvField(optional = true, defaultValue = "-999")
+  private double shapeDistTraveled;
 
-  @CsvField(optional = true)
+  @CsvField(optional = true, defaultValue = "1")
   private int continuousPickup = MISSING_FLEX_VALUE;
 
-  @CsvField(optional = true)
+  @CsvField(optional = true, defaultValue = "1")
   private int continuousDropOff = MISSING_FLEX_VALUE;
 
   @CsvField(optional = true, name = "start_service_area_id", mapping = EntityFieldMappingFactory.class, order = -2)
@@ -104,11 +110,11 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, name = "end_service_area_id", mapping = EntityFieldMappingFactory.class, order = -2)
   private Area endServiceArea;
 
-  @CsvField(optional = true)
-  private double startServiceAreaRadius = MISSING_VALUE;
+  @CsvField(optional = true, defaultValue = "-999")
+  private double startServiceAreaRadius;
 
-  @CsvField(optional = true)
-  private double endServiceAreaRadius = MISSING_VALUE;
+  @CsvField(optional = true, defaultValue = "-999")
+  private double endServiceAreaRadius;
 
   @CsvField(ignore = true)
   private transient StopTimeProxy proxy = null;
@@ -137,17 +143,17 @@ public final class StopTime extends IdentityBean<Integer> implements
   private Note note;
 
   // See https://github.com/MobilityData/gtfs-flex/blob/master/spec/reference.md
-  @CsvField(optional = true, name = "mean_duration_factor")
+  @CsvField(optional = true, name = "mean_duration_factor", defaultValue = "-999.0")
   private double meanDurationFactor = MISSING_VALUE;
 
-  @CsvField(optional = true, name = "mean_duration_offset")
+  @CsvField(optional = true, name = "mean_duration_offset", defaultValue = "-999.0")
   private double meanDurationOffset = MISSING_VALUE;
     
-  @CsvField(optional = true, name = "safe_duration_factor")
-  private double safeDurationFactor = MISSING_VALUE;
+  @CsvField(optional = true, name = "safe_duration_factor", defaultValue = "-999.0")
+  private double safeDurationFactor= MISSING_VALUE;
 
-  @CsvField(optional = true, name = "safe_duration_offset")
-  private double safeDurationOffset = MISSING_VALUE;
+  @CsvField(optional = true, name = "safe_duration_offset", defaultValue = "-999")
+  private double safeDurationOffset;
 
   @CsvField(optional = true, name = "free_running_flag")
   private String freeRunningFlag;
@@ -338,7 +344,10 @@ public final class StopTime extends IdentityBean<Integer> implements
   }
 
   public int getStartPickupDropOffWindow() {
-    if (startPickupDropOffWindow != MISSING_VALUE) {
+    if (startPickupDropOffWindowWithUnderscore != MISSING_VALUE) {
+      return startPickupDropOffWindowWithUnderscore;
+    } else
+      if (startPickupDropOffWindow != MISSING_VALUE) {
       return startPickupDropOffWindow;
     } else {
       return minArrivalTime;
@@ -360,7 +369,10 @@ public final class StopTime extends IdentityBean<Integer> implements
   }
 
   public int getEndPickupDropOffWindow() {
-    if (endPickupDropOffWindow != MISSING_VALUE) {
+    if (endPickupDropOffWindowWithUnderscore != MISSING_VALUE) {
+      return endPickupDropOffWindowWithUnderscore;
+    } else
+      if (endPickupDropOffWindow != MISSING_VALUE) {
       return endPickupDropOffWindow;
     } else {
       return maxDepartureTime;
@@ -370,6 +382,22 @@ public final class StopTime extends IdentityBean<Integer> implements
   public void setEndPickupDropOffWindow(int endPickupDropOffWindow) {
     this.endPickupDropOffWindow = endPickupDropOffWindow;
   }
+
+  public int getEndPickupDropOffWindowWithUnderscore() {
+    return endPickupDropOffWindowWithUnderscore;
+  }
+
+//  public void setEndPickupDropOffWindowWithUnderscore(int endPickupDropOffWindowWithUnderscore) {
+//    this.endPickupDropOffWindowWithUnderscore = endPickupDropOffWindowWithUnderscore;
+//  }
+
+  public int getStartPickupDropOffWindowWithUnderscore() {
+    return startPickupDropOffWindowWithUnderscore;
+  }
+
+//  public void setStartPickupDropOffWindowWithUnderscore(int startPickupDropOffWindowWithUnderscore) {
+//    this.startPickupDropOffWindowWithUnderscore = startPickupDropOffWindowWithUnderscore;
+//  }
 
   @Override
   public boolean isTimepointSet() {

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -111,10 +111,10 @@ public final class StopTime extends IdentityBean<Integer> implements
   private Area endServiceArea;
 
   @CsvField(optional = true, defaultValue = "-999.0")
-  private double startServiceAreaRadius;
+  private double startServiceAreaRadius = MISSING_VALUE;
 
   @CsvField(optional = true, defaultValue = "-999.0")
-  private double endServiceAreaRadius;
+  private double endServiceAreaRadius = MISSING_VALUE;
 
   @CsvField(ignore = true)
   private transient StopTimeProxy proxy = null;
@@ -346,8 +346,7 @@ public final class StopTime extends IdentityBean<Integer> implements
   public int getStartPickupDropOffWindow() {
     if (startPickupDropOffWindowWithUnderscore != MISSING_VALUE) {
       return startPickupDropOffWindowWithUnderscore;
-    } else
-      if (startPickupDropOffWindow != MISSING_VALUE) {
+    } else if (startPickupDropOffWindow != MISSING_VALUE) {
       return startPickupDropOffWindow;
     } else {
       return minArrivalTime;
@@ -371,8 +370,7 @@ public final class StopTime extends IdentityBean<Integer> implements
   public int getEndPickupDropOffWindow() {
     if (endPickupDropOffWindowWithUnderscore != MISSING_VALUE) {
       return endPickupDropOffWindowWithUnderscore;
-    } else
-      if (endPickupDropOffWindow != MISSING_VALUE) {
+    } else if (endPickupDropOffWindow != MISSING_VALUE) {
       return endPickupDropOffWindow;
     } else {
       return maxDepartureTime;

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2012 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.onebusaway.gtfs.serialization.GtfsWriter;
+import org.onebusaway.gtfs.serialization.GtfsWriterTest;
+import org.onebusaway.gtfs.serialization.mappings.InvalidStopTimeException;
+import org.onebusaway.gtfs.services.MockGtfs;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.ServiceCalendarDate;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
+
+import static org.junit.Assert.*;
+
+public class MissingValueTest {
+
+    private MockGtfs _gtfs;
+
+    private static DecimalFormat _format = new DecimalFormat("00", new DecimalFormatSymbols(Locale.ENGLISH));
+
+
+    private File _tmpDirectory;
+
+    @Before
+    public void before() throws IOException {
+        _gtfs = MockGtfs.create();
+
+        //make temp directory for gtfs writing output
+        _tmpDirectory = File.createTempFile("GtfsWriterMissingValueTest-", "-tmp");
+        if (_tmpDirectory.exists())
+            GtfsWriterTest.deleteFileRecursively(_tmpDirectory);
+        _tmpDirectory.mkdirs();
+    }
+
+    @Test
+    public void test() throws IOException {
+        _gtfs.putMinimal();
+        _gtfs.putDefaultTrips();
+        _gtfs.putDefaultStops();
+        _gtfs.putLines("stop_times.txt",
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,mean_duration_factor",
+                "T10-0,100,0,,08:00:00,", "T10-0,200,1,05:55:55,09:00:00,09:00:00");
+
+        GtfsRelationalDao dao = _gtfs.read();
+        assertEquals(2, dao.getAllStopTimes().size());
+
+        GtfsWriter writer = new GtfsWriter();
+        System.out.println("outputlocation: " + _tmpDirectory );
+        writer.setOutputLocation(_tmpDirectory);
+        writer.run(dao);
+
+        Scanner scan = new Scanner(new File(_tmpDirectory + "/stop_times.txt"));
+        boolean foundUnderscoreParam = false;
+        while(scan.hasNext()){
+            String line = scan.nextLine();
+            if(line.contains("end_pickup_dropoff_window")){
+                foundUnderscoreParam = true;
+            }
+        }
+        assertTrue("Column without was not found", foundUnderscoreParam);
+    }
+
+    @Test
+    public void testPutMinimal() throws IOException {
+        _gtfs.putMinimal();
+        // Just make sure it parses without throwing an error.
+        _gtfs.read();
+    }
+
+    @After
+    public void teardown() {
+        deleteFileRecursively(_tmpDirectory);
+    }
+
+    public static void deleteFileRecursively(File file) {
+
+        if (!file.exists())
+            return;
+
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files)
+                    deleteFileRecursively(child);
+            }
+        }
+
+        file.delete();
+    }
+
+}
+
+

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
@@ -51,7 +51,7 @@ public class MissingValueTest {
         _gtfs.putDefaultStops();
         _gtfs.putLines("stop_times.txt",
                 "trip_id,stop_id,stop_sequence,arrival_time,departure_time,mean_duration_factor",
-                "T10-0,100,0,,08:00:00,", "T10-0,200,1,05:55:55,09:00:00,09:00:00");
+                "T10-0,100,0,,08:00:00,", "T10-0,200,1,05:55:55,09:00:00,");
 
         GtfsRelationalDao dao = _gtfs.read();
         assertEquals(2, dao.getAllStopTimes().size());
@@ -62,14 +62,19 @@ public class MissingValueTest {
         writer.run(dao);
 
         Scanner scan = new Scanner(new File(_tmpDirectory + "/stop_times.txt"));
-        boolean foundUnderscoreParam = false;
+        boolean foundEmptyColumn = false;
+        boolean foundProperArrivalTime = false;
         while(scan.hasNext()){
             String line = scan.nextLine();
-            if(line.contains("end_pickup_dropoff_window")){
-                foundUnderscoreParam = true;
+            if(line.contains("mean_duration_factor")){
+                foundEmptyColumn = true;
+            }
+            if(line.contains("arrival_time")){
+                foundProperArrivalTime = true;
             }
         }
-        assertTrue("Column without was not found", foundUnderscoreParam);
+        assertFalse("Empty Column not properly removed", foundEmptyColumn);
+        assertTrue("Column unexpectedly removed", foundProperArrivalTime);
     }
 
     @Test

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
@@ -1,18 +1,3 @@
-/**
- * Copyright (C) 2012 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.onebusaway.gtfs.model;
 
 import java.io.File;
@@ -45,9 +30,6 @@ import static org.junit.Assert.*;
 public class MissingValueTest {
 
     private MockGtfs _gtfs;
-
-    private static DecimalFormat _format = new DecimalFormat("00", new DecimalFormatSymbols(Locale.ENGLISH));
-
 
     private File _tmpDirectory;
 

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/MissingValueTest.java
@@ -78,6 +78,34 @@ public class MissingValueTest {
     }
 
     @Test
+    public void testStartingWithMissingValue() throws IOException {
+        _gtfs.putMinimal();
+        _gtfs.putDefaultTrips();
+        _gtfs.putDefaultStops();
+        _gtfs.putLines("stop_times.txt",
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,timepoint",
+                "T10-0,100,0,,08:00:00,-999", "T10-0,200,1,05:55:55,09:00:00,-999");
+
+        GtfsRelationalDao dao = _gtfs.read();
+        assertEquals(2, dao.getAllStopTimes().size());
+
+        GtfsWriter writer = new GtfsWriter();
+        System.out.println("outputlocation: " + _tmpDirectory );
+        writer.setOutputLocation(_tmpDirectory);
+        writer.run(dao);
+
+        Scanner scan = new Scanner(new File(_tmpDirectory + "/stop_times.txt"));
+        boolean foundTimepoint = false;
+        while(scan.hasNext()){
+            String line = scan.nextLine();
+            if(line.contains("timepoint")){
+                foundTimepoint = true;
+            }
+        }
+        assertFalse("Empty Column not properly removed", foundTimepoint);
+    }
+
+    @Test
     public void testPutMinimal() throws IOException {
         _gtfs.putMinimal();
         // Just make sure it parses without throwing an error.

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
@@ -47,11 +47,10 @@ public class StopTimeWithUnderscoreTest {
         _gtfs.putDefaultTrips();
         _gtfs.putDefaultStops();
         _gtfs.putLines("stop_times.txt",
-                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,mean_duration_factor,",
-                "T10-0,100,0,,08:00:00,", "T10-0,200,1,05:55:55,09:00:00,");
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,end_pickup_drop_off_window",
+                "T10-0,100,0,05:55:55,08:00:00,08:23:23", "T10-0,200,1,05:55:55,09:00:00,08:44:44");
 
         GtfsRelationalDao dao = _gtfs.read();
-        List<StopTime> stopTimes = new ArrayList<>(dao.getAllStopTimes());
         assertEquals(2, dao.getAllStopTimes().size());
 
         GtfsWriter writer = new GtfsWriter();
@@ -60,19 +59,14 @@ public class StopTimeWithUnderscoreTest {
         writer.run(dao);
 
         Scanner scan = new Scanner(new File(_tmpDirectory + "/stop_times.txt"));
-        boolean foundEmptyColumn = false;
-        boolean foundProperArrivalTime = false;
+        boolean foundUnderscoreParam = false;
         while(scan.hasNext()){
             String line = scan.nextLine();
-            if(line.contains("mean_duration_factor")){
-                foundEmptyColumn = true;
-            }
-            if(line.contains("arrival_time")){
-                foundProperArrivalTime = true;
+            if(line.contains("end_pickup_dropoff_window")){
+                foundUnderscoreParam = true;
             }
         }
-        assertFalse("Empty Column not properly removed", foundEmptyColumn);
-        assertTrue("Column unexpectedly removed", foundProperArrivalTime);
+        assertTrue("Column without underscore was not found", foundUnderscoreParam);
     }
 
     @Test
@@ -81,8 +75,8 @@ public class StopTimeWithUnderscoreTest {
         _gtfs.putDefaultTrips();
         _gtfs.putDefaultStops();
         _gtfs.putLines("stop_times.txt",
-                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,mean_duration_factor,end_pickup_dropoff_window",
-                "T10-0,100,0,,08:00:00,,03:33:33", "T10-0,200,1,05:55:55,09:00:00,09:00:00,02:22:22");
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,end_pickup_dropoff_window",
+                "T10-0,100,0,05:55:55,08:00:00,08:23:23", "T10-0,200,1,05:55:55,09:00:00,08:44:44");
 
         GtfsRelationalDao dao = _gtfs.read();
         assertEquals(2, dao.getAllStopTimes().size());

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2012 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.onebusaway.gtfs.serialization.GtfsWriter;
+import org.onebusaway.gtfs.serialization.GtfsWriterTest;
+import org.onebusaway.gtfs.serialization.mappings.InvalidStopTimeException;
+import org.onebusaway.gtfs.services.MockGtfs;
+import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.ServiceCalendarDate;
+import org.onebusaway.gtfs.model.calendar.ServiceDate;
+
+import static org.junit.Assert.*;
+
+public class StopTimeWithUnderscoreTest {
+
+    private MockGtfs _gtfs;
+
+    private static DecimalFormat _format = new DecimalFormat("00", new DecimalFormatSymbols(Locale.ENGLISH));
+
+
+    private File _tmpDirectory;
+
+    @Before
+    public void before() throws IOException {
+        _gtfs = MockGtfs.create();
+
+        //make temp directory for gtfs writing output
+        _tmpDirectory = File.createTempFile("GtfsWriterMissingValueTest-", "-tmp");
+        if (_tmpDirectory.exists())
+            GtfsWriterTest.deleteFileRecursively(_tmpDirectory);
+        _tmpDirectory.mkdirs();
+    }
+
+    @Test
+    public void testWithUnderScore() throws IOException {
+        _gtfs.putMinimal();
+        _gtfs.putDefaultTrips();
+        _gtfs.putDefaultStops();
+        _gtfs.putLines("stop_times.txt",
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,mean_duration_factor,",
+                "T10-0,100,0,,08:00:00,", "T10-0,200,1,05:55:55,09:00:00,");
+
+        GtfsRelationalDao dao = _gtfs.read();
+        List<StopTime> stopTimes = new ArrayList<>(dao.getAllStopTimes());
+        assertEquals(2, dao.getAllStopTimes().size());
+
+        GtfsWriter writer = new GtfsWriter();
+        System.out.println("outputlocation: " + _tmpDirectory );
+        writer.setOutputLocation(_tmpDirectory);
+        writer.run(dao);
+
+        Scanner scan = new Scanner(new File(_tmpDirectory + "/stop_times.txt"));
+        boolean foundEmptyColumn = false;
+        boolean foundProperArrivalTime = false;
+        while(scan.hasNext()){
+            String line = scan.nextLine();
+            if(line.contains("mean_duration_factor")){
+                foundEmptyColumn = true;
+            }
+            if(line.contains("arrival_time")){
+                foundProperArrivalTime = true;
+            }
+        }
+        assertFalse("Empty Column not properly removed", foundEmptyColumn);
+        assertTrue("Column unexpectedly removed", foundProperArrivalTime);
+    }
+
+    @Test
+    public void testWithoutUnderscore() throws IOException {
+        _gtfs.putMinimal();
+        _gtfs.putDefaultTrips();
+        _gtfs.putDefaultStops();
+        _gtfs.putLines("stop_times.txt",
+                "trip_id,stop_id,stop_sequence,arrival_time,departure_time,mean_duration_factor,end_pickup_dropoff_window",
+                "T10-0,100,0,,08:00:00,,03:33:33", "T10-0,200,1,05:55:55,09:00:00,09:00:00,02:22:22");
+
+        GtfsRelationalDao dao = _gtfs.read();
+        assertEquals(2, dao.getAllStopTimes().size());
+
+        GtfsWriter writer = new GtfsWriter();
+        System.out.println("outputlocation: " + _tmpDirectory );
+        writer.setOutputLocation(_tmpDirectory);
+        writer.run(dao);
+
+        Scanner scan = new Scanner(new File(_tmpDirectory + "/stop_times.txt"));
+        boolean foundUnderscoreParam = false;
+        while(scan.hasNext()){
+            String line = scan.nextLine();
+            if(line.contains("end_pickup_dropoff_window")){
+                foundUnderscoreParam = true;
+            }
+        }
+        assertTrue("Column without underscore was not found", foundUnderscoreParam);
+    }
+
+    @Test
+    public void testPutMinimal() throws IOException {
+        _gtfs.putMinimal();
+        // Just make sure it parses without throwing an error.
+        _gtfs.read();
+    }
+
+    @After
+    public void teardown() {
+        deleteFileRecursively(_tmpDirectory);
+    }
+
+    public static void deleteFileRecursively(File file) {
+
+        if (!file.exists())
+            return;
+
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files)
+                    deleteFileRecursively(child);
+            }
+        }
+
+        file.delete();
+    }
+
+}
+
+

--- a/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
+++ b/onebusaway-gtfs/src/test/java/org/onebusaway/gtfs/model/StopTimeWithUnderscoreTest.java
@@ -1,18 +1,3 @@
-/**
- * Copyright (C) 2012 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.onebusaway.gtfs.model;
 
 import java.io.File;
@@ -43,9 +28,6 @@ public class StopTimeWithUnderscoreTest {
 
     private MockGtfs _gtfs;
 
-    private static DecimalFormat _format = new DecimalFormat("00", new DecimalFormatSymbols(Locale.ENGLISH));
-
-
     private File _tmpDirectory;
 
     @Before
@@ -53,7 +35,7 @@ public class StopTimeWithUnderscoreTest {
         _gtfs = MockGtfs.create();
 
         //make temp directory for gtfs writing output
-        _tmpDirectory = File.createTempFile("GtfsWriterMissingValueTest-", "-tmp");
+        _tmpDirectory = File.createTempFile("GtfsWriterStopTimeWithUnderScoreTest-", "-tmp");
         if (_tmpDirectory.exists())
             GtfsWriterTest.deleteFileRecursively(_tmpDirectory);
         _tmpDirectory.mkdirs();


### PR DESCRIPTION
**Summary:**

Added new csvfield `end_pickup_drop_off_window` and `start_pickup_drop_off_window` and altered getters so that `start_pickup_drop_off_window` and `start_pickup_dropoff_window` map to same place and output to the same place

Added `default_value` to the `@CsvField` annotations

Added unit tests

**Expected behavior:** 

These changes allow for stop times using dropoff or drop_off to be read correctly
Also now stop times will remove columns which have only missing values
